### PR TITLE
Removed unnecessary config for next

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ yarn add @shelf/eslint-config --dev
 }
 ```
 
-#### TypeScript `.eslintrc`
+#### TypeScript or TypeScript + Next `.eslintrc`
 
 ```json
 {
@@ -90,22 +90,6 @@ $ yarn add @shelf/eslint-config --dev
   "rules": {
     "testing-library/no-wait-for-empty-callback": "error",
     "testing-library/no-await-sync-query": "error"
-  }
-}
-```
-
-#### React with Typescript and Next `.eslintrc`
-
-```json
-{
-  "extends": ["@shelf/eslint-config/frontend-next"],
-  "settings": {
-    "react": {
-      "version": "17.0.2"
-    }
-  },
-  "rules": {
-    "react/prop-types": "warn"
   }
 }
 ```

--- a/frontend-next.js
+++ b/frontend-next.js
@@ -1,6 +1,0 @@
-const nextConfig = require('eslint-config-next');
-const typescriptConfig = require('./frontend-typescript');
-
-module.exports = {
-  extends: [...nextConfig, ...typescriptConfig],
-};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "frontend-typescript.js",
     "frontend-typescript-vue.js",
     "frontend-testing-library.js",
-    "frontend-next.js",
     "meteor.js",
     "typescript.js"
   ],


### PR DESCRIPTION
Since `eslint-config-next` works if it's just added as a dependency, there is no need for an extra file.