### PR TITLE
Add rule about arrow functions return style. Camelcase fixes

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -44,6 +44,7 @@ module.exports = {
     'no-use-before-define': ['error', 'nofunc'],
     ...consistentTypeImports,
     'multiline-comment-style': ['error', 'separate-lines'],
+    'arrow-body-style': ['error', {'as-needed': true, 'requireReturnForObjectLiteral': true}],
   },
   overrides: [allowRequireInConfigs, noExplicitReturnTypeInTests],
 };

--- a/typescript.js
+++ b/typescript.js
@@ -37,14 +37,14 @@ module.exports = {
     ...consistentTypeAssertions,
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
     '@typescript-eslint/no-non-null-assertion': 'off', // we want to allow using the "!" operator
-    camelcase: 'error',
+    camelcase: ['error', {properties: 'never', ignoreGlobals: true}],
     eqeqeq: ['error', 'smart'],
     'new-cap': 'error',
     'no-extend-native': 'error',
     'no-use-before-define': ['error', 'nofunc'],
     ...consistentTypeImports,
     'multiline-comment-style': ['error', 'separate-lines'],
-    'arrow-body-style': ['error', {'as-needed': true, 'requireReturnForObjectLiteral': true}],
+    'arrow-body-style': ['error', {'as-needed': true, requireReturnForObjectLiteral: true}],
   },
   overrides: [allowRequireInConfigs, noExplicitReturnTypeInTests],
 };


### PR DESCRIPTION
https://eslint.org/docs/rules/arrow-body-style

# before
![image](https://user-images.githubusercontent.com/3817380/149906873-abd9b68d-753f-4967-90dd-ff1ccb4f36af.png)
# after
![image](https://user-images.githubusercontent.com/3817380/149906917-758c1380-966b-460e-a77f-f6ac0f9f2864.png)
