### PR TITLE
Move eslint plugins to peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,17 @@
     "@typescript-eslint/eslint-plugin": "5.15.0",
     "@typescript-eslint/parser": "5.15.0",
     "eslint-config-next": "11.1.2",
-    "eslint-config-prettier": "8.5.0",
+    "eslint-config-prettier": "8.5.0"
+  },
+  "devDependencies": {
+    "husky": "7.0.4",
+    "lint-staged": "12.3.7",
+    "prettier": "2.5.1"
+  },
+  "peerDependencies": {
+    "eslint": "7.x || 8.x",
+    "prettier": "2.x",
+    "eslint-plugin-sonarjs": "0.12.0",
     "eslint-plugin-babel": "5.3.1",
     "eslint-plugin-import": "2.25.4",
     "eslint-plugin-jest": "26.1.1",
@@ -46,18 +56,8 @@
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-react": "7.29.4",
     "eslint-plugin-react-hooks": "4.3.0",
-    "eslint-plugin-sonarjs": "0.12.0",
     "eslint-plugin-testing-library": "5.1.0",
     "eslint-plugin-vue": "8.5.0"
-  },
-  "devDependencies": {
-    "husky": "7.0.4",
-    "lint-staged": "12.3.7",
-    "prettier": "2.5.1"
-  },
-  "peerDependencies": {
-    "eslint": "7.x || 8.x",
-    "prettier": "2.x"
   },
   "lint-staged": {
     "*.{js,json,css,md,yml}": [


### PR DESCRIPTION
This should fix our problems on the app consumers sides where we duplicate some plugins from our shared config.

https://eslint.org/docs/developer-guide/shareable-configs#publishing-a-shareable-config