### PR TITLE
INT-11 Switch existing non-working lodash/chain rule to custom plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-prettier": "5.0.0",
     "eslint-plugin-react": "7.33.1",
     "eslint-plugin-react-hooks": "4.6.0",
-    "eslint-plugin-shelf-lodash-rules": "./plugins/eslint-plugin-shelf-lodash-rules",
+    "eslint-plugin-shelf-lodash-rules": "file:plugins/eslint-plugin-shelf-lodash-rules",
     "eslint-plugin-sonarjs": "0.19.0",
     "eslint-plugin-testing-library": "5.11.0",
     "eslint-plugin-vue": "9.16.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-prettier": "5.0.0",
     "eslint-plugin-react": "7.33.1",
     "eslint-plugin-react-hooks": "4.6.0",
-    "eslint-plugin-shelf-lodash-rules": "file:plugins/eslint-plugin-shelf-lodash-rules",
+    "eslint-plugin-shelf-lodash-rules": "file:./plugins/eslint-plugin-shelf-lodash-rules",
     "eslint-plugin-sonarjs": "0.19.0",
     "eslint-plugin-testing-library": "5.11.0",
     "eslint-plugin-vue": "9.16.1",

--- a/plugins/eslint-plugin-shelf-lodash-rules/index.js
+++ b/plugins/eslint-plugin-shelf-lodash-rules/index.js
@@ -1,0 +1,10 @@
+module.exports.rules = require('./rules');
+
+module.exports.configs = {
+  all: {
+    plugins: ['shelf-lodash-rules'],
+    rules: {
+      'shelf-lodash-rules/no-chain-es': 'error',
+    },
+  },
+};

--- a/plugins/eslint-plugin-shelf-lodash-rules/package.json
+++ b/plugins/eslint-plugin-shelf-lodash-rules/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint-plugin-shelf-lodash-rules",
+  "version": "0.0.1",
+  "main": "./index.js"
+}

--- a/plugins/eslint-plugin-shelf-lodash-rules/rules/index.js
+++ b/plugins/eslint-plugin-shelf-lodash-rules/rules/index.js
@@ -1,0 +1,5 @@
+const noChainES = require('./no-chain-es');
+
+module.exports = {
+  'no-chain-es': noChainES,
+};

--- a/plugins/eslint-plugin-shelf-lodash-rules/rules/no-chain-es.js
+++ b/plugins/eslint-plugin-shelf-lodash-rules/rules/no-chain-es.js
@@ -1,0 +1,40 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Forbid the usage of lodash-es chain method',
+      category: 'Best Practices',
+      recommended: true,
+    },
+  },
+  create: function (context) {
+    return {
+      ImportDeclaration: function (node) {
+        const {
+          specifiers,
+          source: {value: sourceValue},
+        } = node;
+        let nodeToReport;
+
+        if (sourceValue === 'lodash-es') {
+          const chainSpecifier = specifiers.find(
+            (specifier) => specifier.imported && specifier.imported.name === 'chain',
+          );
+
+          if (chainSpecifier) {
+            nodeToReport = chainSpecifier;
+          }
+        } else if (sourceValue === 'lodash-es/chain') {
+          nodeToReport = specifiers[0];
+        }
+
+        if (nodeToReport) {
+          context.report({
+            node: nodeToReport,
+            message: 'Avoid importing lodash-es chain method',
+          });
+        }
+      },
+    };
+  },
+};

--- a/rules/you-dont-need-lodash.json
+++ b/rules/you-dont-need-lodash.json
@@ -10,6 +10,5 @@
   "you-dont-need-lodash-underscore/map": "error",
   "you-dont-need-lodash-underscore/filter": "error",
   "you-dont-need-lodash-underscore/size": "error",
-  "you-dont-need-lodash-underscore/includes": "error",
-  "you-dont-need-lodash-underscore/chain": "error"
+  "you-dont-need-lodash-underscore/includes": "error"
 }

--- a/typescript.js
+++ b/typescript.js
@@ -19,7 +19,11 @@ const typescriptRules = require('./rules/typescript');
 const restrictedPackagesImportRules = require('./rules/restricted-packages-import.json');
 
 module.exports = {
-  extends: [...commonExtends, 'plugin:you-dont-need-lodash-underscore/compatible'],
+  extends: [
+    ...commonExtends,
+    'plugin:you-dont-need-lodash-underscore/compatible',
+    'plugin:shelf-lodash-rules/all',
+  ],
   plugins: commonPlugins,
   env,
   ...tsParser,


### PR DESCRIPTION
Actually `you-dont-need-lodash-underscore/chain` rule doesn't exists in `you-dont-need-lodash-underscore` package
<img width="893" alt="image" src="https://github.com/shelfio/eslint-config/assets/2472080/2fba76ff-9497-4701-93db-191cb90885d2">
