### PR TITLE
Remove prohibit relative shelf import rule

### DIFF
--- a/frontend.js
+++ b/frontend.js
@@ -37,9 +37,6 @@ module.exports = {
     'sonarjs/cognitive-complexity': ['error', 18],
     'multiline-comment-style': 'off',
     'no-unreachable': 'error',
-    'react/react-in-jsx-scope': "off",
-    "no-restricted-imports": [1, {
-      "patterns": ["@shelf/*/lib/*"]
-    }]
+    'react/react-in-jsx-scope': "off"
   },
 };


### PR DESCRIPTION
We have a lot of packages where relative imports are expected, so this rule created more of a noise at the moment 

This also would not be needed once we switch everything to ESM, as it would just fail to build code & would be catched by TS