### PR TITLE
Require SWR mutation state for remote operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **Breaking:** Frontend configs now enforce `shelf/prefer-swr-mutation` for manually managed remote loading state.
+
 ## 3.0.0
 
 Override recommended no explicit type any in tests

--- a/README.md
+++ b/README.md
@@ -68,6 +68,34 @@ export default [
 
 The legacy `typescript.js` and `frontend-typescript.js` entrypoints stay supported for repos that still format through Prettier.
 
+## Remote Mutations
+
+Frontend configs enforce `shelf/prefer-swr-mutation`. The rule reports React loading state that is manually toggled around an awaited `fetch`, Axios call, or Shelf API/client call:
+
+```tsx
+// Incorrect
+const [isSaving, setIsSaving] = useState(false);
+
+const save = async () => {
+  setIsSaving(true);
+  try {
+    await ContentApi.save();
+  } finally {
+    setIsSaving(false);
+  }
+};
+```
+
+Use the mutation lifecycle as the source of truth instead:
+
+```tsx
+const {trigger: save, isMutating: isSaving} = useSWRMutation('save-content', () =>
+  ContentApi.save(),
+);
+```
+
+Local UI state and asynchronous work that does not call a remote API remain valid.
+
 ## Publish
 
 ```sh

--- a/frontend-typescript-no-prettier.js
+++ b/frontend-typescript-no-prettier.js
@@ -20,6 +20,7 @@ import consistentTypeImports from './rules/consistent-type-imports.js';
 import baseNoPrettierConfig from './base-no-prettier.js';
 import env from './common/env.js';
 import restrictedPackages from './rules/restricted-packages-import.js';
+import preferSWRMutation, {swrMutationPlugin} from './rules/prefer-swr-mutation.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -59,6 +60,7 @@ export default [
       '@typescript-eslint': tsEslint.plugin,
       node,
       'testing-library': fixupPluginRules(testingLibrary),
+      shelf: swrMutationPlugin,
     },
 
     languageOptions: {
@@ -99,6 +101,7 @@ export default [
       ...typescriptRules,
       '@typescript-eslint/no-unused-vars': ['error', {ignoreRestSiblings: true}],
       ...youDontNeedLodash,
+      ...preferSWRMutation,
     },
   },
   overrides.allowRequireInConfigs,

--- a/frontend-typescript.js
+++ b/frontend-typescript.js
@@ -20,6 +20,7 @@ import consistentTypeImports from './rules/consistent-type-imports.js';
 import baseConfig from './base.js';
 import env from './common/env.js';
 import restrictedPackages from './rules/restricted-packages-import.js';
+import preferSWRMutation, {swrMutationPlugin} from './rules/prefer-swr-mutation.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -60,6 +61,7 @@ export default [
       '@typescript-eslint': tsEslint.plugin,
       node,
       'testing-library': fixupPluginRules(testingLibrary),
+      shelf: swrMutationPlugin,
     },
 
     languageOptions: {
@@ -100,6 +102,7 @@ export default [
       ...typescriptRules,
       '@typescript-eslint/no-unused-vars': ['error', {ignoreRestSiblings: true}],
       ...youDontNeedLodash,
+      ...preferSWRMutation,
     },
   },
   overrides.allowRequireInConfigs,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
   },
   "scripts": {
-    "test": "echo ok",
+    "test": "node --test",
     "prepare": "husky",
     "lint": "eslint . --fix"
   },

--- a/rules/prefer-swr-mutation.js
+++ b/rules/prefer-swr-mutation.js
@@ -1,0 +1,240 @@
+const functionTypes = new Set([
+  'ArrowFunctionExpression',
+  'FunctionDeclaration',
+  'FunctionExpression',
+]);
+
+const remoteClientName = /(?:Api|API|Client|Service)$/;
+
+const isFunction = (node) => functionTypes.has(node.type);
+const isNode = (node) => Boolean(node && typeof node.type === 'string');
+const toArray = (value) => (Array.isArray(value) ? value : [value]);
+const getChildren = (node, visitorKeys) =>
+  (visitorKeys[node.type] ?? []).flatMap((key) => toArray(node[key])).filter(isNode);
+
+const walk = (node, visitorKeys, visit) => {
+  if (!isNode(node)) {
+    return;
+  }
+
+  if (visit(node) === false) {
+    return;
+  }
+
+  getChildren(node, visitorKeys).forEach((child) => walk(child, visitorKeys, visit));
+};
+
+const isFalseLiteral = (node) => node?.type === 'Literal' && node.value === false;
+const isIdentifier = (node) => node?.type === 'Identifier';
+const isIdentifierNamed = (node, name) => isIdentifier(node) && node.name === name;
+
+const isReactUseState = (node) =>
+  node.type === 'MemberExpression' &&
+  !node.computed &&
+  isIdentifierNamed(node.object, 'React') &&
+  isIdentifierNamed(node.property, 'useState');
+
+const isUseStateCall = (node) => {
+  if (node?.type !== 'CallExpression' || !isFalseLiteral(node.arguments[0])) {
+    return false;
+  }
+
+  return isIdentifierNamed(node.callee, 'useState') || isReactUseState(node.callee);
+};
+
+const getRootIdentifier = (node) => {
+  switch (node?.type) {
+    case 'Identifier':
+      return node;
+    case 'ChainExpression':
+      return getRootIdentifier(node.expression);
+    case 'MemberExpression':
+      return getRootIdentifier(node.object);
+    default:
+      return undefined;
+  }
+};
+
+const isRemoteCall = (node) => {
+  if (node.type !== 'CallExpression') {
+    return false;
+  }
+
+  const root = getRootIdentifier(node.callee);
+
+  if (!root) {
+    return false;
+  }
+
+  return root.name === 'fetch' || root.name === 'axios' || remoteClientName.test(root.name);
+};
+
+const containsRemoteCall = (node, visitorKeys) => {
+  let found = false;
+
+  walk(node, visitorKeys, (child) => {
+    if (child !== node && isFunction(child)) {
+      return false;
+    }
+
+    if (!isRemoteCall(child)) {
+      return undefined;
+    }
+
+    found = true;
+
+    return false;
+  });
+
+  return found;
+};
+
+const isSetterCall = (node, setterName, value) => {
+  if (node.type !== 'CallExpression' || !isIdentifierNamed(node.callee, setterName)) {
+    return false;
+  }
+
+  const [argument] = node.arguments;
+
+  return argument?.type === 'Literal' && argument.value === value;
+};
+
+const isSWRFetcher = (node) =>
+  node.parent?.type === 'CallExpression' &&
+  node.parent.arguments[1] === node &&
+  isIdentifierNamed(node.parent.callee, 'useSWRMutation');
+
+const collectFunctions = (owner, visitorKeys) => {
+  const functions = [owner];
+
+  walk(owner.body, visitorKeys, (node) => {
+    if (isFunction(node)) {
+      functions.push(node);
+    }
+  });
+
+  return functions;
+};
+
+const isRemoteAwait = (node, visitorKeys) =>
+  node.type === 'AwaitExpression' && containsRemoteCall(node.argument, visitorKeys);
+
+const hasManualRemoteState = (node, setterName, visitorKeys) => {
+  if (isSWRFetcher(node)) {
+    return false;
+  }
+
+  let startsLoading = false;
+  let stopsLoading = false;
+  let awaitsRemoteCall = false;
+
+  walk(node.body, visitorKeys, (child) => {
+    if (isFunction(child)) {
+      return false;
+    }
+
+    startsLoading ||= isSetterCall(child, setterName, true);
+    stopsLoading ||= isSetterCall(child, setterName, false);
+
+    awaitsRemoteCall ||= isRemoteAwait(child, visitorKeys);
+
+    return undefined;
+  });
+
+  return startsLoading && stopsLoading && awaitsRemoteCall;
+};
+
+const getStatePair = (node) => {
+  if (node.id.type !== 'ArrayPattern') {
+    return undefined;
+  }
+
+  const [state, setter] = node.id.elements;
+
+  if (!isIdentifier(state)) {
+    return undefined;
+  }
+
+  if (!isIdentifier(setter)) {
+    return undefined;
+  }
+
+  return {state, setter};
+};
+
+const getCandidate = (node, owner) => {
+  const pair = getStatePair(node);
+
+  if (!pair || !isUseStateCall(node.init)) {
+    return undefined;
+  }
+
+  return {node, owner, setterName: pair.setter.name};
+};
+
+export const preferSWRMutationRule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Require SWR mutation state for user-triggered remote operations',
+    },
+    schema: [],
+    messages: {
+      preferSWRMutation:
+        'Use useSWRMutation and its isMutating state instead of hand-rolling remote loading state with useState.',
+    },
+  },
+
+  create(context) {
+    const candidates = [];
+    const functionStack = [];
+    const {visitorKeys} = context.sourceCode;
+
+    const enterFunction = (node) => functionStack.push(node);
+    const exitFunction = () => functionStack.pop();
+
+    return {
+      ArrowFunctionExpression: enterFunction,
+      'ArrowFunctionExpression:exit': exitFunction,
+      FunctionDeclaration: enterFunction,
+      'FunctionDeclaration:exit': exitFunction,
+      FunctionExpression: enterFunction,
+      'FunctionExpression:exit': exitFunction,
+      VariableDeclarator(node) {
+        const owner = functionStack.at(-1);
+
+        if (!owner) {
+          return;
+        }
+
+        const candidate = getCandidate(node, owner);
+
+        if (candidate) {
+          candidates.push(candidate);
+        }
+      },
+      'Program:exit'() {
+        for (const candidate of candidates) {
+          const functions = collectFunctions(candidate.owner, visitorKeys);
+          const violatesRule = functions.some((node) =>
+            hasManualRemoteState(node, candidate.setterName, visitorKeys),
+          );
+
+          if (violatesRule) {
+            context.report({node: candidate.node, messageId: 'preferSWRMutation'});
+          }
+        }
+      },
+    };
+  },
+};
+
+export const swrMutationPlugin = {
+  rules: {
+    'prefer-swr-mutation': preferSWRMutationRule,
+  },
+};
+
+export default {
+  'shelf/prefer-swr-mutation': 'error',
+};

--- a/rules/prefer-swr-mutation.test.js
+++ b/rules/prefer-swr-mutation.test.js
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import tsParser from '@typescript-eslint/parser';
+import {RuleTester} from 'eslint';
+import frontendConfig from '../frontend-typescript.js';
+import noPrettierConfig from '../frontend-typescript-no-prettier.js';
+import {preferSWRMutationRule} from './prefer-swr-mutation.js';
+
+const enablesRule = (config) =>
+  config.some(
+    (entry) => entry.plugins?.shelf && entry.rules?.['shelf/prefer-swr-mutation'] === 'error',
+  );
+
+test('frontend configs enforce the rule', () => {
+  assert.equal(enablesRule(frontendConfig), true);
+  assert.equal(enablesRule(noPrettierConfig), true);
+});
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 'latest',
+    parser: tsParser,
+    parserOptions: {ecmaFeatures: {jsx: true}},
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('prefer-swr-mutation', preferSWRMutationRule, {
+  valid: [
+    `
+      function DownloadButton() {
+        const {trigger, isMutating} = useSWRMutation(
+          {api: 'ContentApi.download'},
+          () => ContentApi.download()
+        );
+
+        return {trigger, isMutating};
+      }
+    `,
+    `
+      function Menu() {
+        const [isOpen, setIsOpen] = useState(false);
+        return {isOpen, setIsOpen};
+      }
+    `,
+    `
+      function AnimatedButton() {
+        const [isLoading, setIsLoading] = useState(false);
+
+        const animate = async () => {
+          setIsLoading(true);
+          await waitForAnimation();
+          setIsLoading(false);
+        };
+
+        return animate;
+      }
+    `,
+    `
+      function AdvancedMutation() {
+        const [isProcessing, setIsProcessing] = useState(false);
+
+        return useSWRMutation('key', async () => {
+          setIsProcessing(true);
+          await ContentApi.update();
+          setIsProcessing(false);
+        });
+      }
+    `,
+    `
+      async function downloadWithoutLoadingState() {
+        return await ContentApi.download();
+      }
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+        function DownloadButton() {
+          const [isDownloading, setIsDownloading] = useState(false);
+
+          const download = async () => {
+            setIsDownloading(true);
+            try {
+              await ContentApi.download();
+            } finally {
+              setIsDownloading(false);
+            }
+          };
+
+          return {download, isDownloading};
+        }
+      `,
+      errors: [{messageId: 'preferSWRMutation'}],
+    },
+    {
+      code: `
+        function SaveButton() {
+          const [isSaving, setIsSaving] = React.useState(false);
+
+          async function save() {
+            setIsSaving(true);
+            await fetch('/save');
+            setIsSaving(false);
+          }
+
+          return save;
+        }
+      `,
+      errors: [{messageId: 'preferSWRMutation'}],
+    },
+    {
+      code: `
+        const UploadButton = () => {
+          const [uploading, setUploading] = useState(false);
+
+          const upload = async () => {
+            setUploading(true);
+            await apiClient.files.upload();
+            setUploading(false);
+          };
+
+          return upload;
+        };
+      `,
+      errors: [{messageId: 'preferSWRMutation'}],
+    },
+    {
+      code: `
+        function CacheTestButton() {
+          const [isTestingCache, setIsTestingCache] = useState(false);
+
+          const testCache = async () => {
+            setIsTestingCache(true);
+            try {
+              await AssistantsApi.testCache();
+            } finally {
+              setIsTestingCache(false);
+            }
+          };
+
+          return testCache;
+        }
+      `,
+      errors: [{messageId: 'preferSWRMutation'}],
+    },
+  ],
+});


### PR DESCRIPTION
## What

- Add `shelf/prefer-swr-mutation` to both frontend TypeScript presets.
- Report boolean React state manually toggled around awaited fetch, Axios, API, client, or service calls.
- Add rule coverage, migration examples, and an executable test suite.

## Why

Remote operation state should come from the mutation lifecycle. This keeps loading, error, and concurrency behavior owned by one abstraction instead of repeated component state.

## How

- Correlate `useState(false)` setters with `true -> awaited remote call -> false` inside the same handler.
- Accept local UI state, non-remote asynchronous work, and inline `useSWRMutation` fetchers.
- Enable the rule as an error in frontend presets.

**Breaking change:** Existing consumers with matching manual request state must migrate to `useSWRMutation` and `isMutating`, or add an explained suppression for exceptional workflows.
