### PR TITLE
Add no-testid-only-tests rule for frontend test files

### DIFF
--- a/frontend-typescript-no-prettier.js
+++ b/frontend-typescript-no-prettier.js
@@ -21,6 +21,7 @@ import baseNoPrettierConfig from './base-no-prettier.js';
 import env from './common/env.js';
 import restrictedPackages from './rules/restricted-packages-import.js';
 import preferSWRMutation, {swrMutationPlugin} from './rules/prefer-swr-mutation.js';
+import noTestidOnlyTests, {testidOnlyTestsPlugin} from './rules/no-testid-only-tests.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -31,6 +32,11 @@ const compat = new FlatCompat({
 
 const testingLibraryReact = {
   rules: compat.extends('plugin:testing-library/react')[0].rules,
+  files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
+};
+
+const testidOnlyTests = {
+  rules: noTestidOnlyTests,
   files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
 };
 
@@ -52,6 +58,7 @@ export default [
     },
   },
   testingLibraryReact,
+  testidOnlyTests,
   {
     plugins: {
       react: fixupPluginRules(react),
@@ -60,7 +67,7 @@ export default [
       '@typescript-eslint': tsEslint.plugin,
       node,
       'testing-library': fixupPluginRules(testingLibrary),
-      shelf: swrMutationPlugin,
+      shelf: {rules: {...swrMutationPlugin.rules, ...testidOnlyTestsPlugin.rules}},
     },
 
     languageOptions: {

--- a/frontend-typescript.js
+++ b/frontend-typescript.js
@@ -21,6 +21,7 @@ import baseConfig from './base.js';
 import env from './common/env.js';
 import restrictedPackages from './rules/restricted-packages-import.js';
 import preferSWRMutation, {swrMutationPlugin} from './rules/prefer-swr-mutation.js';
+import noTestidOnlyTests, {testidOnlyTestsPlugin} from './rules/no-testid-only-tests.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -31,6 +32,11 @@ const compat = new FlatCompat({
 
 const testingLibraryReact = {
   rules: compat.extends('plugin:testing-library/react')[0].rules,
+  files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
+};
+
+const testidOnlyTests = {
+  rules: noTestidOnlyTests,
   files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
 };
 
@@ -53,6 +59,7 @@ export default [
     },
   },
   testingLibraryReact,
+  testidOnlyTests,
   {
     plugins: {
       react: fixupPluginRules(react),
@@ -61,7 +68,7 @@ export default [
       '@typescript-eslint': tsEslint.plugin,
       node,
       'testing-library': fixupPluginRules(testingLibrary),
-      shelf: swrMutationPlugin,
+      shelf: {rules: {...swrMutationPlugin.rules, ...testidOnlyTestsPlugin.rules}},
     },
 
     languageOptions: {

--- a/rules/no-testid-only-tests.js
+++ b/rules/no-testid-only-tests.js
@@ -117,20 +117,36 @@ const matcherAssertion = (node) => {
   return {argument: unwrapAwait(base.arguments[0]), matcherName, negated};
 };
 
-const collectTestidVariables = (callback, visitorKeys) => {
-  const names = new Set();
+// Maps every resolved identifier reference to its variable so `expect(x)`
+// honors the scope that actually declared `x`, not any same-named variable
+// elsewhere in the test.
+const buildReferenceMap = (scopeManager) => {
+  const map = new Map();
 
-  walk(callback, visitorKeys, (node) => {
-    if (
-      node.type === 'VariableDeclarator' &&
-      node.id.type === 'Identifier' &&
-      isTestidQueryCall(node.init)
-    ) {
-      names.add(node.id.name);
-    }
-  });
+  const collect = (scope) => {
+    scope.references.forEach((reference) => {
+      if (reference.resolved) {
+        map.set(reference.identifier, reference.resolved);
+      }
+    });
+    scope.childScopes.forEach(collect);
+  };
 
-  return names;
+  collect(scopeManager.globalScope);
+
+  return map;
+};
+
+const isTestidVariable = (variable) => {
+  if (!variable) {
+    return false;
+  }
+
+  const writes = variable.references
+    .map((reference) => reference.writeExpr)
+    .filter(Boolean);
+
+  return writes.length > 0 && writes.every(isTestidQueryCall);
 };
 
 export const noTestidOnlyTestsRule = {
@@ -147,7 +163,14 @@ export const noTestidOnlyTestsRule = {
   },
 
   create(context) {
-    const {visitorKeys} = context.sourceCode;
+    const {scopeManager, visitorKeys} = context.sourceCode;
+    let referenceMap = null;
+
+    const resolveVariable = (identifier) => {
+      referenceMap ??= buildReferenceMap(scopeManager);
+
+      return referenceMap.get(identifier);
+    };
 
     return {
       CallExpression(node) {
@@ -165,7 +188,6 @@ export const noTestidOnlyTestsRule = {
           return;
         }
 
-        const testidVariables = collectTestidVariables(callback, visitorKeys);
         let total = 0;
         let presence = 0;
 
@@ -180,7 +202,7 @@ export const noTestidOnlyTestsRule = {
           const targetsTestid =
             isTestidQueryCall(assertion.argument) ||
             (assertion.argument.type === 'Identifier' &&
-              testidVariables.has(assertion.argument.name));
+              isTestidVariable(resolveVariable(assertion.argument)));
 
           if (
             targetsTestid &&

--- a/rules/no-testid-only-tests.js
+++ b/rules/no-testid-only-tests.js
@@ -1,0 +1,210 @@
+/**
+ * Reject tests whose only assertions prove data-testid hooks exist.
+ *
+ * A test that renders a component and asserts `getByTestId(...)` presence
+ * restates the JSX: it cannot fail while the surface is broken, and
+ * `getByTestId` already throws when the hook is missing. Assert behavior the
+ * user can observe (roles, accessible names, text, values, callbacks)
+ * instead; testids stay welcome as selectors for those real assertions.
+ */
+
+const functionTypes = new Set([
+  'ArrowFunctionExpression',
+  'FunctionDeclaration',
+  'FunctionExpression',
+]);
+
+const testNames = new Set(['it', 'test']);
+const chainModifiers = new Set(['not', 'resolves', 'rejects']);
+const presenceMatchers = new Set([
+  'toBeInTheDocument',
+  'toBeVisible',
+  'toBeTruthy',
+  'toBeDefined',
+]);
+const testidQuery = /^(?:get|getAll|query|queryAll|find|findAll)ByTestId$/;
+
+const isNode = (node) => Boolean(node && typeof node.type === 'string');
+const toArray = (value) => (Array.isArray(value) ? value : [value]);
+const getChildren = (node, visitorKeys) =>
+  (visitorKeys[node.type] ?? []).flatMap((key) => toArray(node[key])).filter(isNode);
+
+const walk = (node, visitorKeys, visit) => {
+  if (!isNode(node)) {
+    return;
+  }
+
+  visit(node);
+  getChildren(node, visitorKeys).forEach((child) => walk(child, visitorKeys, visit));
+};
+
+const unwrapAwait = (node) => (node?.type === 'AwaitExpression' ? node.argument : node);
+
+const isTestidQueryCall = (node) => {
+  const call = unwrapAwait(node);
+
+  if (call?.type !== 'CallExpression') {
+    return false;
+  }
+
+  const {callee} = call;
+
+  if (callee.type === 'Identifier') {
+    return testidQuery.test(callee.name);
+  }
+
+  return (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.property.type === 'Identifier' &&
+    testidQuery.test(callee.property.name)
+  );
+};
+
+// Resolves `it`, `test`, `it.only`, and the `it.each(table)(title, fn)`
+// invocation down to the base test identifier.
+const testCallName = (callee) => {
+  if (callee.type === 'Identifier') {
+    return callee.name;
+  }
+
+  if (callee.type === 'MemberExpression' && !callee.computed) {
+    return testCallName(callee.object);
+  }
+
+  if (callee.type === 'CallExpression') {
+    return testCallName(callee.callee);
+  }
+
+  return null;
+};
+
+// Unwraps `expect(arg).not.resolves...matcher()` chains; returns the expect
+// argument, the matcher name, and whether the chain negates.
+const matcherAssertion = (node) => {
+  if (
+    node.type !== 'CallExpression' ||
+    node.callee.type !== 'MemberExpression' ||
+    node.callee.computed ||
+    node.callee.property.type !== 'Identifier'
+  ) {
+    return null;
+  }
+
+  const matcherName = node.callee.property.name;
+  let negated = false;
+  let base = node.callee.object;
+
+  while (
+    base.type === 'MemberExpression' &&
+    !base.computed &&
+    base.property.type === 'Identifier' &&
+    chainModifiers.has(base.property.name)
+  ) {
+    negated = negated || base.property.name === 'not';
+    base = base.object;
+  }
+
+  if (
+    base.type !== 'CallExpression' ||
+    base.callee.type !== 'Identifier' ||
+    base.callee.name !== 'expect' ||
+    base.arguments.length === 0
+  ) {
+    return null;
+  }
+
+  return {argument: unwrapAwait(base.arguments[0]), matcherName, negated};
+};
+
+const collectTestidVariables = (callback, visitorKeys) => {
+  const names = new Set();
+
+  walk(callback, visitorKeys, (node) => {
+    if (
+      node.type === 'VariableDeclarator' &&
+      node.id.type === 'Identifier' &&
+      isTestidQueryCall(node.init)
+    ) {
+      names.add(node.id.name);
+    }
+  });
+
+  return names;
+};
+
+export const noTestidOnlyTestsRule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Reject tests whose only assertions prove data-testid hooks exist',
+    },
+    schema: [],
+    messages: {
+      testidOnly:
+        'Every assertion in this test just proves a data-testid exists; getByTestId already throws when the hook is missing. Assert observable behavior (role, accessible name, text, value, callback) or delete the test.',
+    },
+  },
+
+  create(context) {
+    const {visitorKeys} = context.sourceCode;
+
+    return {
+      CallExpression(node) {
+        const name = testCallName(node.callee);
+
+        if (name === null || !testNames.has(name)) {
+          return;
+        }
+
+        const callback = node.arguments.findLast((argument) =>
+          functionTypes.has(argument.type),
+        );
+
+        if (!callback) {
+          return;
+        }
+
+        const testidVariables = collectTestidVariables(callback, visitorKeys);
+        let total = 0;
+        let presence = 0;
+
+        walk(callback.body, visitorKeys, (child) => {
+          const assertion = matcherAssertion(child);
+
+          if (!assertion) {
+            return;
+          }
+
+          total += 1;
+          const targetsTestid =
+            isTestidQueryCall(assertion.argument) ||
+            (assertion.argument.type === 'Identifier' &&
+              testidVariables.has(assertion.argument.name));
+
+          if (
+            targetsTestid &&
+            !assertion.negated &&
+            presenceMatchers.has(assertion.matcherName)
+          ) {
+            presence += 1;
+          }
+        });
+
+        if (total > 0 && total === presence) {
+          context.report({node: node.callee, messageId: 'testidOnly'});
+        }
+      },
+    };
+  },
+};
+
+export const testidOnlyTestsPlugin = {
+  rules: {
+    'no-testid-only-tests': noTestidOnlyTestsRule,
+  },
+};
+
+export default {
+  'shelf/no-testid-only-tests': 'error',
+};

--- a/rules/no-testid-only-tests.test.js
+++ b/rules/no-testid-only-tests.test.js
@@ -81,6 +81,20 @@ ruleTester.run('no-testid-only-tests', noTestidOnlyTestsRule, {
         expect(screen.getByTestId('widget')).toBeInTheDocument();
       };
     `,
+    // A nested helper's testid variable must not poison a same-named outer
+    // variable that came from a role query.
+    `
+      it('renders the primary action', () => {
+        render(<Widget />);
+        const readHook = () => {
+          const button = screen.getByTestId('widget-primary');
+          return button;
+        };
+        readHook();
+        const button = screen.getByRole('button');
+        expect(button).toBeInTheDocument();
+      });
+    `,
   ],
   invalid: [
     {
@@ -138,6 +152,19 @@ ruleTester.run('no-testid-only-tests', noTestidOnlyTestsRule, {
         it.each([['a'], ['b']])('renders %s', (id) => {
           render(<Widget />);
           expect(screen.getByTestId(id)).toBeInTheDocument();
+        });
+      `,
+      errors: testidOnly,
+    },
+    // Block-scoped testid variables are still resolved to their declaration.
+    {
+      code: `
+        it('exposes the trigger per row', () => {
+          render(<Widget />);
+          for (const row of rows) {
+            const trigger = within(row).getByTestId('row-trigger');
+            expect(trigger).toBeInTheDocument();
+          }
         });
       `,
       errors: testidOnly,

--- a/rules/no-testid-only-tests.test.js
+++ b/rules/no-testid-only-tests.test.js
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import tsParser from '@typescript-eslint/parser';
+import {RuleTester} from 'eslint';
+import frontendConfig from '../frontend-typescript.js';
+import noPrettierConfig from '../frontend-typescript-no-prettier.js';
+import {noTestidOnlyTestsRule} from './no-testid-only-tests.js';
+
+const enablesRule = (config) =>
+  config.some(
+    (entry) =>
+      entry.files &&
+      entry.rules?.['shelf/no-testid-only-tests'] === 'error' &&
+      config.some((other) => other.plugins?.shelf?.rules?.['no-testid-only-tests']),
+  );
+
+test('frontend configs enforce the rule for test files', () => {
+  assert.equal(enablesRule(frontendConfig), true);
+  assert.equal(enablesRule(noPrettierConfig), true);
+});
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 'latest',
+    parser: tsParser,
+    parserOptions: {ecmaFeatures: {jsx: true}},
+    sourceType: 'module',
+  },
+});
+
+const testidOnly = [{messageId: 'testidOnly'}];
+
+ruleTester.run('no-testid-only-tests', noTestidOnlyTestsRule, {
+  valid: [
+    // Testid used as a selector for a behavioral assertion.
+    `
+      it('labels the save action', () => {
+        render(<Widget />);
+        expect(screen.getByTestId('widget-save')).toHaveAccessibleName('Save');
+      });
+    `,
+    // Mixed: one presence check plus a real assertion.
+    `
+      it('opens the dropdown', async () => {
+        render(<Widget />);
+        expect(screen.getByTestId('widget-trigger')).toBeInTheDocument();
+        expect(screen.getByTestId('widget-option-a')).toHaveTextContent('Alpha');
+      });
+    `,
+    // Absence assertions are real conditional-rendering checks.
+    `
+      it('hides the dialog by default', () => {
+        render(<Widget />);
+        expect(screen.queryByTestId('widget-dialog')).not.toBeInTheDocument();
+      });
+    `,
+    // Presence of a non-testid query is out of scope here.
+    `
+      it('renders the dialog', () => {
+        render(<Widget />);
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+    `,
+    // No assertions at all is not this rule's concern.
+    `
+      it('renders', () => {
+        render(<Widget />);
+      });
+    `,
+    // Variables from testid queries feeding behavioral assertions are fine.
+    `
+      it('enables the trigger', () => {
+        render(<Widget />);
+        const trigger = screen.getByTestId('widget-trigger');
+        expect(trigger).toHaveAccessibleName('Open');
+      });
+    `,
+    // Non-test functions are ignored.
+    `
+      const helper = () => {
+        expect(screen.getByTestId('widget')).toBeInTheDocument();
+      };
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+        it('exposes stable selectors', () => {
+          render(<Widget />);
+          expect(screen.getByTestId('widget-trigger')).toBeInTheDocument();
+          expect(screen.getByTestId('widget-content')).toBeVisible();
+        });
+      `,
+      errors: testidOnly,
+    },
+    {
+      code: `
+        test('renders hooks', () => {
+          render(<Widget />);
+          expect(getByTestId('widget')).toBeTruthy();
+        });
+      `,
+      errors: testidOnly,
+    },
+    {
+      code: `
+        it('scopes rows', () => {
+          render(<Widget />);
+          expect(within(list).getByTestId('row-1')).toBeInTheDocument();
+        });
+      `,
+      errors: testidOnly,
+    },
+    // Assigning the query to a variable first is the same banned test.
+    {
+      code: `
+        it('exposes the trigger', () => {
+          render(<Widget />);
+          const trigger = screen.getByTestId('widget-trigger');
+          expect(trigger).toBeInTheDocument();
+        });
+      `,
+      errors: testidOnly,
+    },
+    // Async variants and awaited queries count too.
+    {
+      code: `
+        it('shows the panel', async () => {
+          render(<Widget />);
+          expect(await screen.findByTestId('widget-panel')).toBeInTheDocument();
+        });
+      `,
+      errors: testidOnly,
+    },
+    // The it.each(table)(title, fn) invocation is still a test block.
+    {
+      code: `
+        it.each([['a'], ['b']])('renders %s', (id) => {
+          render(<Widget />);
+          expect(screen.getByTestId(id)).toBeInTheDocument();
+        });
+      `,
+      errors: testidOnly,
+    },
+  ],
+});


### PR DESCRIPTION
## What

- Add `shelf/no-testid-only-tests`: rejects tests whose every assertion just proves a `data-testid` hook exists (`expect(getByTestId('x')).toBeInTheDocument()` and friends, including queries assigned to a variable before the assertion).
- Enable it as `error` in both frontend presets, scoped to the existing test-file globs.

## Why

A test that renders a component and asserts its testids exist restates the JSX: it cannot fail while the surface is broken, and `getByTestId` already throws when the hook is missing, so the assertion is dead weight. Testids remain welcome as selectors for real assertions — accessible names, text, values, state, callbacks — which the rule allows; only tests with nothing else devolve to an error.

## How

- AST-based, following the `prefer-swr-mutation` rule structure: resolves `it`/`test` through `.each(table)(title, fn)` invocations and `.only`/`.skip` modifiers, unwraps `expect(...).not.resolves...` matcher chains, and tracks variables initialized from `*ByTestId` queries so assigning the query first cannot evade the rule.
- Presence matchers counted: `toBeInTheDocument`, `toBeVisible`, `toBeTruthy`, `toBeDefined`; negated chains and all other matchers count as real assertions.
- RuleTester coverage for valid/invalid cases plus a preset-wiring assertion, mirroring the existing rule tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)